### PR TITLE
Add try/except cases to catch bad AppleScript responses.

### DIFF
--- a/slack_tunes/updater.py
+++ b/slack_tunes/updater.py
@@ -48,11 +48,17 @@ def update_status(is_playing, text=None, tokens=None):
 
 
 def spotify_song():
-    return osascript('Spotify', 'if player state is playing then name of current track & " - " & artist of current track')  # pep8
+    try:
+        return osascript('Spotify', 'if player state is playing then artist of current track & " - " & name of current track')  # pep8
+    except subprocess.CalledProcessError:
+        return None
 
 
 def itunes_song():
-    return osascript('iTunes', 'if player state is playing then name of current track & " - " & artist of current track')  # pep8
+    try:
+        return osascript('iTunes', 'if player state is playing then artist of current track & " - " & name of current track')  # pep8
+    except subprocess.CalledProcessError:
+        return None
 
 
 def check_song(old_status=None, first_run=False, tokens=None):


### PR DESCRIPTION
Hey! I don't have Spotify installed on my machine (only iTunes) — and running the script caused an exception:

```40:45: syntax error: Expected “then”, etc. but found identifier. (-2741)
Traceback (most recent call last):
  File "/Users/bkreeger/.pyenv/versions/2.7.13/bin/slack-tunes", line 27, in <module>
    main()
  File "/Users/bkreeger/.pyenv/versions/2.7.13/bin/slack-tunes", line 21, in main
    current_status = check_song(current_status, first_run, SLACK_API_TOKENS)
  File "/Users/bkreeger/.pyenv/versions/2.7.13/lib/python2.7/site-packages/slack_tunes/updater.py", line 59, in check_song
    current_status = spotify_song()
  File "/Users/bkreeger/.pyenv/versions/2.7.13/lib/python2.7/site-packages/slack_tunes/updater.py", line 51, in spotify_song
    return osascript('Spotify', 'if player state is playing then name of current track & " - " & artist of current track')  # pep8
  File "/Users/bkreeger/.pyenv/versions/2.7.13/lib/python2.7/site-packages/slack_tunes/updater.py", line 14, in osascript
    return subprocess.check_output(command, shell=True).strip()
  File "/Users/bkreeger/.pyenv/versions/2.7.13/lib/python2.7/subprocess.py", line 219, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'osascript -e 'tell application "Spotify" to if player state is playing then name of current track & " - " & artist of current track as string'' returned non-zero exit status 1
```

Listening for the `subprocess.CalledProcessError` and returning `None` made things all better for me. So here it is!